### PR TITLE
Fixed bug with same generated value for multiple program runs.

### DIFF
--- a/regen.go
+++ b/regen.go
@@ -96,6 +96,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp/syntax"
+	"time"
 )
 
 // DefaultMaxUnboundedRepeatCount is default value for MaxUnboundedRepeatCount.
@@ -138,7 +139,7 @@ type GeneratorArgs struct {
 func (a *GeneratorArgs) initialize() error {
 	var seed int64
 	if nil == a.RngSource {
-		seed = rand.Int63()
+		seed = time.Now().UnixNano()
 	} else {
 		seed = a.RngSource.Int63()
 	}


### PR DESCRIPTION
At program start we have identical seed, so in case of using regen.Generate function - we get identical values.
It is better to get time based seed or always use NewGenerator with user defined seed, or set default seed at programm start.